### PR TITLE
请升级com.fasterxml.jackson.core:jackson-databind组件版本以解决7个安全漏洞

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 	 <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.9-SNAPSHOT</version>
+            <version>2.9.10.8</version>/version>
          </dependency>
     </dependencies>
 


### PR DESCRIPTION
将 **com.fasterxml.jackson.core:jackson-databind** 组件从2.9.10.9-SNAPSHOT 版本升级至 2.9.10.8版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2019-28847](https://www.oscs1024.com/hd/MPS-2019-28847) | Fastjson <= 1.2.60 版本远程代码执行漏洞 | 严重
2 | [MPS-2019-28848](https://www.oscs1024.com/hd/MPS-2019-28848) | Fastjson < 1.2.60 版本拒绝服务漏洞 | 严重
3 | [MPS-2018-27011](https://www.oscs1024.com/hd/MPS-2018-27011) | Fastjson 1.2.25-1.2.47版本远程代码执行漏洞 | 严重
4 | [MPS-2022-11320](https://www.oscs1024.com/hd/MPS-2022-11320) | Fastjson < 1.2.83 任意代码执行漏洞 | 高危
5 | [MPS-2020-40828](https://www.oscs1024.com/hd/MPS-2020-40828) | Fastjson < 1.2.67远程命令执行漏洞 | 高危
6 | [MPS-2020-39708](https://www.oscs1024.com/hd/MPS-2020-39708) | Fastjson <=1.2.68 远程代码执行漏洞 | 严重
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
