### PR TITLE
请升级com.fasterxml.jackson.core:jackson-databind组件版本以解决7个安全漏洞

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 	 <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.9-SNAPSHOT</version>
+            <version>2.9.10.8</version>/version>
          </dependency>
     </dependencies>
 


### PR DESCRIPTION
将 **com.fasterxml.jackson.core:jackson-databind** 组件从2.9.10.9-SNAPSHOT 版本升级至 2.9.10.8版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2022-6242](https://www.oscs1024.com/hd/MPS-2022-6242) | FasterXML jackson-databind 拒绝服务漏洞 | 高危
2 | [MPS-2019-11533](https://www.oscs1024.com/hd/MPS-2019-11533) | FasterXML jackson-databind 反序列化漏洞(HikariCP gadget绕过) | 严重
3 | [MPS-2022-58653](https://www.oscs1024.com/hd/MPS-2022-58653) | FasterXML jackson-databind 小于2.14.0-rc1拒绝服务漏洞 | 中危
4 | [MPS-2022-58654](https://www.oscs1024.com/hd/MPS-2022-58654) |  FasterXML jackson-databind 小于2.13.4拒绝服务漏洞 | 中危
5 | [MPS-2019-12676](https://www.oscs1024.com/hd/MPS-2019-12676) | FasterXML jackson-databind 反序列化漏洞(ehcache gadget绕过) | 严重
6 | [MPS-2022-12433](https://www.oscs1024.com/hd/MPS-2022-12433) | com.fasterxml.jackson.core:jackson-databind 存在反序列化漏洞 | 高危
7 | [MPS-2019-11529](https://www.oscs1024.com/hd/MPS-2019-11529) | FasterXML jackson-databind 反序列化漏洞(HikariCP gadget绕过) | 严重
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
